### PR TITLE
moved to retep998/winapi-rs crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,10 +8,10 @@ log = "*"
 libc = "*"
 
 [target.'cfg(target_os = "windows")'.dependencies]
-kernel32-sys = { git = "https://github.com/application-developer-DA/winapi-rs.git", branch = "0.2" }
-shell32-sys = { git = "https://github.com/application-developer-DA/winapi-rs.git", branch = "0.2" }
-user32-sys = { git = "https://github.com/application-developer-DA/winapi-rs.git", branch = "0.2" }
-winapi = { git = "https://github.com/application-developer-DA/winapi-rs.git", branch = "0.2" }
+kernel32-sys = { git = "https://github.com/retep998/winapi-rs.git", branch = "0.2" }
+shell32-sys = { git = "https://github.com/retep998/winapi-rs.git", branch = "0.2" }
+user32-sys = { git = "https://github.com/retep998/winapi-rs.git", branch = "0.2" }
+winapi = { git = "https://github.com/retep998/winapi-rs.git", branch = "0.2" }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 objc = "*"


### PR DESCRIPTION
@application-developer-DA not sure what patches your version contained. but at least with this change we unblock the mac/linux target compilations